### PR TITLE
LOOP-676: Fixed asset paths

### DIFF
--- a/loopdk.make
+++ b/loopdk.make
@@ -243,6 +243,7 @@ projects[strongarm][version] = "2.0"
 
 projects[style_settings][subdir] = "contrib"
 projects[style_settings][version] = "2.0"
+projects[style_settings][patch][] = "patches/style_settings-path.patch"
 
 projects[system_status][subdir] = "contrib"
 projects[system_status][version] = "3.3"

--- a/patches/style_settings-path.patch
+++ b/patches/style_settings-path.patch
@@ -1,0 +1,13 @@
+diff --git a/style_settings.module b/style_settings.module
+index 0bb821d..fc9c24c 100644
+--- a/style_settings.module
++++ b/style_settings.module
+@@ -144,7 +144,7 @@ function style_settings_rewrite($path, $reset = FALSE) {
+     $realpath = drupal_realpath($new_path);
+     $dirname = dirname($realpath);
+     file_prepare_directory($dirname, FILE_CREATE_DIRECTORY);
+-    $old_data = file_get_contents(file_create_url($path));
++    $old_data = file_get_contents(drupal_realpath($path) ?: file_create_url($path));
+ 
+     // Prefix all paths, ignoring absolute paths.
+     _drupal_build_css_path(NULL, base_path() . dirname($path) . '/');

--- a/themes/loop/template.php
+++ b/themes/loop/template.php
@@ -39,14 +39,14 @@ function loop_preprocess_page(&$variables) {
         menu_set_active_item('user');
 
         // Add notifications script.
-        $subscriptions_alter_flags = $GLOBALS['base_root'] . '/' . path_to_theme() . '/scripts/subscriptions-alter-flags.js';
+        $subscriptions_alter_flags = path_to_theme() . '/scripts/subscriptions-alter-flags.js';
         drupal_add_js($subscriptions_alter_flags, 'file');
       }
     }
   }
 
   if ($variables['is_front']) {
-    $update_script_path = $GLOBALS['base_root'] . '/' . path_to_theme() . '/scripts/frontpage-column-width.js';
+    $update_script_path = path_to_theme() . '/scripts/frontpage-column-width.js';
     drupal_add_js($update_script_path, 'file');
   }
 
@@ -221,10 +221,8 @@ function loop_preprocess_panels_pane(&$variables) {
 
   // Add message variable for panel pane.
   if ($variables['pane']->subtype == 'user_messages-panel_pane_1' || $variables['pane']->subtype == 'user_messages-panel_pane_5') {
-    global $base_root;
-
     $variables['message_count'] = _loop_fetch_user_new_notifications();
-    $update_script_path = $base_root . '/' . path_to_theme() . '/scripts/update-new-notifications.js';
+    $update_script_path = path_to_theme() . '/scripts/update-new-notifications.js';
     drupal_add_js($update_script_path, 'file');
     if (arg(0) == 'user') {
       $variables['theme_hook_suggestions'][] = 'panels_pane__user_page_unread_messages';
@@ -947,7 +945,7 @@ function loop_preprocess_views_view(&$vars) {
     $vars['user_messages'] = $new_message_count;
 
     // Add update notification script.
-    $update_script_path = $GLOBALS['base_root'] . '/' . path_to_theme() . '/scripts/update-new-notifications.js';
+    $update_script_path = path_to_theme() . '/scripts/update-new-notifications.js';
     drupal_add_js($update_script_path, 'file');
   }
 


### PR DESCRIPTION
1. Removes use of absolute urls when adding scripts.
2. Patches `style_settings` module to not load `css` from absolute urls.