### PR TITLE
LOOP-694: Fixed notify_editorial_office block placement

### DIFF
--- a/modules/loop_notify_editorial_office/loop_notify_editorial_office.module
+++ b/modules/loop_notify_editorial_office/loop_notify_editorial_office.module
@@ -163,3 +163,41 @@ function loop_notify_editorial_office_mail($key, &$message, $params) {
     $message['body'][] = t('Regards, @site_name', array('@site_name' => variable_get('site_name')));
   }
 }
+
+/**
+ * Implements hook_panels_pre_render().
+ *
+ * Inserts our “Notify editorial office” block before anything else in the
+ * navigation (beta) region on documents and document collections.
+ */
+function loop_notify_editorial_office_panels_pre_render($panels_display, $renderer)
+{
+  // Check if we have loop_documents-loop_documents_navigation in the panels.
+  if (isset($panels_display->content['new-cf7f5491-5b00-4348-9070-bdef0eeb1ee1'])) {
+    // Build a pane with our custom block (loop_neo_block).
+    $pane = new stdClass();
+    $pane->pid = 'new-10095d72-bcfa-402b-af60-3bcf092c515a';
+    $pane->panel = 'beta';
+    $pane->type = 'block';
+    $pane->subtype = 'loop_notify_editorial_office-loop_neo_block';
+    $pane->shown = TRUE;
+    $pane->access = array();
+    $pane->configuration = array(
+      'override_title' => 0,
+      'override_title_text' => '',
+      'override_title_heading' => 'h2',
+    );
+    $pane->cache = array();
+    $pane->style = array(
+      'settings' => null,
+    );
+    $pane->css = array();
+    $pane->extras = array();
+    $pane->position = -1;
+    $pane->locks = array();
+    $pane->uuid = '10095d72-bcfa-402b-af60-3bcf092c515a';
+    $panels_display->content['new-10095d72-bcfa-402b-af60-3bcf092c515a'] = $pane;
+    // Insert our pane at before anything else.
+    array_unshift($panels_display->panels['beta'], 'new-10095d72-bcfa-402b-af60-3bcf092c515a');
+  }
+}

--- a/themes/loop/templates/panels/layouts/default/default.inc
+++ b/themes/loop/templates/panels/layouts/default/default.inc
@@ -5,12 +5,6 @@
  * Implementation of hook_panels_layouts().
  */
 
-$notify_editors_block = '';
-
-if(module_exists('loop_notify_editorial_office')) {
-  $notify_editors_block = module_invoke('loop_notify_editorial_office', 'block_view', 'loop_neo_block');
-}
-
 $plugin = array(
   'title' => t('Default'),
   'category' => t('Loop custom'),
@@ -21,5 +15,4 @@ $plugin = array(
     'beta' => t('Beta'),
     'gamma' => t('Gamma'),
   ),
-  'notify_editors' => $notify_editors_block,
 );


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-694

This original ~hack~fix breaks display of pages (for unknown reasons). This “fix” is also (probably) a hack, but I cannot find `hook_panels_pane_alter()` or similar …